### PR TITLE
Update to v4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
   "require": {
     "components/jquery": ">=1.11.0",
     "fortawesome/font-awesome": ">=4.4.0",
-    "froala/wysiwyg-editor": ">=4.0.19",
-    "froala/wysiwyg-editor-php-sdk": "4.0.19"
+    "froala/wysiwyg-editor": ">=4.1.0",
+    "froala/wysiwyg-editor-php-sdk": "4.1.0"
   },
   "support": {
     "issues": "https://github.com/froala/froala-editor-php-sdk/issues",


### PR DESCRIPTION
 - Fixed, pasting rich content in safari does not work as expected
 - Fixed, empty paragraphs getting created when merging cells if the table is wrapped using `html.wrap`
 - Fixed, table row with `display: none` style applied does not get's counted
 - Fixed, TypeError: Cannot read properties of undefined (reading 'which')
 - Fixed, font size does not work when `contenteditable="false"` is used
 - Fixed, errors while dragging a `div` block tries to drop in its own container
 - Fixed, editor content scrolls up while pressing backspace in `iframe` mode
 - Fixed, incorrect behavior on iPad safari when backspacing on korean text
 - Fixed, Toolbar Sizes / Responsiveness is not relative to editor width
 - Fixed, viewport jumps to top when toggling between fullScreen
 - Fixed, text overlapping on emoticons
 - Fixed, inconsistent API for uploading files
 - Fixed, adding new row does not work with table header
 - Fixed, the toolbarBottom on mobile devices
 - Fixed, markdown UI breaks when enabling the iframe option
 - Fixed, accessibility features are not working for special character
 - Fixed, accessibility features are not working for emoticons
 - Fixed, hovering over the toolbar buttons generates lot of errors in console
 - Fixed, font formatting gets reset after inserting a table
 - Fixed, spacing and number lists are not respected when pasting from MS Word
 - Updated thirdparty plugins in examples
 - Fixed, editor freezes when pasting a large content
 - Fixed, image alignment does not work as expected inside existing Iframe